### PR TITLE
V0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Version 0.1.1
 * Icons for Battery devices now reflect the current state of the Battery Charge. When new Batteries are inserted the Voltage is typically around 3.2V to 3.3V. And by experience the Unit stops working at around 2.3V +/- 0.1V. So the Icon stage reflects that Interval
+* Fixed documentation error in README.md, listing the wrong sensors
 
 ### Version 0.1.0
 * Initial Release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # List of Changes
 
+### Version 0.1.1
+* Icons for Battery devices now reflect the current state of the Battery Charge. When new Batteries are inserted the Voltage is typically around 3.2V to 3.3V. And by experience the Unit stops working at around 2.3V +/- 0.1V. So the Icon stage reflects that Interval
+
 ### Version 0.1.0
 * Initial Release.

--- a/README.md
+++ b/README.md
@@ -36,20 +36,19 @@ sensor:
     wind_unit: kmh
     monitored_conditions:
       - temperature
+      - dewpoint
       - feels_like_temperature
       - heat_index
       - wind_chill
-      - dewpoint
       - wind_speed
+      - wind_bearing
+      - wind_speed_rapid
+      - wind_bearing_rapid
       - wind_gust
       - wind_lull
-      - wind_bearing
       - wind_direction
       - precipitation
       - precipitation_rate
-      - precipitation_last_1hr
-      - precipitation_last_24hr
-      - precipitation_yesterday
       - humidity
       - pressure
       - uv

--- a/custom_updater.json
+++ b/custom_updater.json
@@ -1,10 +1,10 @@
 {
-   "smartweatherUDP" : {
-      "updated_at" : "2019-04-15",
-      "local_location" : "/custom_components/smartweatherudp/sensor.py",
-      "version" : "0.1.0",
-      "changelog" : "https://github.com/briis/smartweatherudp/blob/master/CHANGELOG.md",
-      "visit_repo" : "https://github.com/briis/smartweatherudp",
-      "remote_location" : "https://raw.githubusercontent.com/briis/smartweatherudp/master/sensor.py"
-   }
+    "smartweatherUDP": {
+        "updated_at": "2019-04-15",
+        "local_location": "/custom_components/smartweatherudp/sensor.py",
+        "version": "0.1.1",
+        "changelog": "https://github.com/briis/smartweatherudp/blob/master/CHANGELOG.md",
+        "visit_repo": "https://github.com/briis/smartweatherudp",
+        "remote_location": "https://raw.githubusercontent.com/briis/smartweatherudp/master/sensor.py"
+    }
 }

--- a/sensor.py
+++ b/sensor.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity import Entity, generate_entity_id
 
 REQUIREMENTS = ['pysmartweatherudp==0.1.5']
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 DOMAIN = 'smartweatherudp'
 
@@ -143,7 +143,35 @@ class SmartWeatherReceiver(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend."""
-        return SENSOR_TYPES[self._sensor][2]
+        if 'Battery' in self._name:
+            if hasattr(self._data, self._sensor):
+                voltage = float(getattr(self._data, self._sensor))
+                if not (voltage is None):
+                    if voltage < 2.3:
+                        return 'mdi:battery-alert'
+                    elif voltage < 2.4:
+                        return 'mdi:battery-10'
+                    elif voltage < 2.5:
+                        return 'mdi:battery-20'
+                    elif voltage < 2.6:
+                        return 'mdi:battery-30'
+                    elif voltage < 2.7:
+                        return 'mdi:battery-40'
+                    elif voltage < 2.8:
+                        return 'mdi:battery-50'
+                    elif voltage < 2.9:
+                        return 'mdi:battery-60'
+                    elif voltage < 3.0:
+                        return 'mdi:battery-70'
+                    elif voltage < 3.1:
+                        return 'mdi:battery-80'
+                    elif voltage < 3.2:
+                        return 'mdi:battery-90'
+                    else:
+                        return 'mdi:battery'
+            return 'mdi:battery'
+        else:
+            return SENSOR_TYPES[self._sensor][2]
 
     @property
     def device_class(self):


### PR DESCRIPTION
* Icons for Battery devices now reflect the current state of the Battery Charge. When new Batteries are inserted the Voltage is typically around 3.2V to 3.3V. And by experience the Unit stops working at around 2.3V +/- 0.1V. So the Icon stage reflects that Interval
* Fixed documentation error in README.md, listing the wrong sensors
