### PR TITLE
Updated to support the 'Great Migration'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # List of Changes
 
+### Version 0.1.2
+* Added `manifest.json` to ensure compliance with Home Assistant >= 0.92.x. If Custom Updater is not the latest version, this file needs to be downloaded manually before upgrading
+
 ### Version 0.1.1
 * Icons for Battery devices now reflect the current state of the Battery Charge. When new Batteries are inserted the Voltage is typically around 3.2V to 3.3V. And by experience the Unit stops working at around 2.3V +/- 0.1V. So the Icon stage reflects that Interval
 * Fixed documentation error in README.md, listing the wrong sensors

--- a/custom_updater.json
+++ b/custom_updater.json
@@ -1,10 +1,13 @@
 {
     "smartweatherUDP": {
-        "updated_at": "2019-04-15",
+        "updated_at": "2019-04-29",
         "local_location": "/custom_components/smartweatherudp/sensor.py",
-        "version": "0.1.1",
+        "version": "0.1.2",
         "changelog": "https://github.com/briis/smartweatherudp/blob/master/CHANGELOG.md",
         "visit_repo": "https://github.com/briis/smartweatherudp",
-        "remote_location": "https://raw.githubusercontent.com/briis/smartweatherudp/master/sensor.py"
+        "remote_location": "https://raw.githubusercontent.com/briis/smartweatherudp/master/sensor.py",
+        "resources": [
+            "https://raw.githubusercontent.com/briis/smartweatherudp/master/manifest.json"
+        ]
     }
 }

--- a/sensor.py
+++ b/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.const import (ATTR_ATTRIBUTION, CONF_MONITORED_CONDITIONS,
                                  TEMP_CELSIUS, UNIT_UV_INDEX)
 from homeassistant.helpers.entity import Entity, generate_entity_id
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 DOMAIN = 'smartweatherudp'
 


### PR DESCRIPTION
* Added `manifest.json` to ensure compliance with Home Assistant >= 0.92.x. If Custom Updater is not the latest version, this file needs to be downloaded manually before upgrading
