### PR TITLE
Update UV_INDEX const for HA 0.109

### DIFF
--- a/custom_components/smartweatherudp/sensor.py
+++ b/custom_components/smartweatherudp/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.const import (ATTR_ATTRIBUTION, CONF_MONITORED_CONDITIONS,
                                  DEVICE_CLASS_PRESSURE,
                                  DEVICE_CLASS_TEMPERATURE,
                                  DEVICE_CLASS_BATTERY,
-                                 TEMP_CELSIUS, UNIT_UV_INDEX)
+                                 TEMP_CELSIUS, UV_INDEX)
 from homeassistant.helpers.entity import Entity, generate_entity_id
 
 DOMAIN = 'smartweatherudp'
@@ -46,7 +46,7 @@ SENSOR_TYPES = {
     'precipitation_rate': ['Rain rate', 'mm/h', 'mdi:weather-pouring', None, 'in/h'],
     'humidity': ['Humidity', '%', 'mdi:water-percent', DEVICE_CLASS_HUMIDITY, None],
     'pressure': ['Pressure', 'hPa', 'mdi:gauge', DEVICE_CLASS_PRESSURE, 'inHg'],
-    'uv': ['UV', UNIT_UV_INDEX,'mdi:weather-sunny', None, None],
+    'uv': ['UV', UV_INDEX,'mdi:weather-sunny', None, None],
     'solar_radiation': ['Solar Radiation', 'W/m2', 'mdi:solar-power', None, None],
     'illuminance': ['Illuminance', 'Lx', 'mdi:brightness-5', DEVICE_CLASS_ILLUMINANCE, None],
     'lightning_count': ['Lightning Count', None, 'mdi:flash', None, None],


### PR DESCRIPTION
Per home-assistant/core#34164 UNIT was dropped form UNIT_UV_INDEX, this caused an error loading the custom_component with 0.109.0b0.