### PR TITLE
Add required version number to home assistant manifest (and bump version to release)

### DIFF
--- a/custom_components/smartweatherudp/__init__.py
+++ b/custom_components/smartweatherudp/__init__.py
@@ -1,3 +1,3 @@
 """ Get data from Smart Weather station via UDP. """
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"

--- a/custom_components/smartweatherudp/manifest.json
+++ b/custom_components/smartweatherudp/manifest.json
@@ -3,6 +3,7 @@
     "name": "WeatherFlow Smart Weather Component for Home Assistant using UDP Transport",
     "documentation": "https://github.com/briis/smartweatherudp",
     "dependencies": [],
+    "version": "0.1.8",
     "codeowners": ["@briis"],
     "requirements": ["pysmartweatherudp==0.1.7"]
 }

--- a/custom_updater.json
+++ b/custom_updater.json
@@ -1,8 +1,8 @@
 {
     "smartweatherUDP": {
-        "updated_at": "2019-04-29",
+        "updated_at": "2021-07-03",
         "local_location": "/custom_components/smartweatherudp/__init__.py",
-        "version": "0.1.7",
+        "version": "0.1.8",
         "changelog": "https://github.com/briis/smartweatherudp/blob/master/CHANGELOG.md",
         "visit_repo": "https://github.com/briis/smartweatherudp",
         "remote_location": "https://raw.githubusercontent.com/briis/smartweatherudp/master/__init__.py",


### PR DESCRIPTION
Adding a version number to manifest.json, bumping version numbers so that this can be released

https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes#versions
The version key is required from Home Assistant version 2021.6